### PR TITLE
Sync Portal Fields between Portal API go, PUB and PHD.

### DIFF
--- a/postgres-driver/application.go
+++ b/postgres-driver/application.go
@@ -28,35 +28,44 @@ const (
 
 type dbApplication struct {
 	ApplicationID        string         `db:"application_id"`
-	ContactEmail         sql.NullString `db:"contact_email"`
-	CreatedAt            sql.NullTime   `db:"created_at"`
-	Description          sql.NullString `db:"description"`
-	Name                 sql.NullString `db:"name"`
-	Owner                sql.NullString `db:"owner"`
-	UpdatedAt            sql.NullTime   `db:"updated_at"`
-	URL                  sql.NullString `db:"url"`
 	UserID               sql.NullString `db:"user_id"`
+	Name                 sql.NullString `db:"name"`
+	Status               sql.NullString `db:"status"`
+	ContactEmail         sql.NullString `db:"contact_email"`
+	Description          sql.NullString `db:"description"`
 	FAPublicKey          sql.NullString `db:"fa_public_key"`
 	FASignature          sql.NullString `db:"fa_signature"`
 	FAClientPublicKey    sql.NullString `db:"fa_client_public_key"`
 	FAVersion            sql.NullString `db:"fa_version"`
-	GAPublicKey          sql.NullString `db:"ga_public_key"`
-	GASignature          sql.NullString `db:"ga_signature"`
-	GAClientPublicKey    sql.NullString `db:"ga_client_public_key"`
-	GAVersion            sql.NullString `db:"ga_version"`
 	FACPublicKey         sql.NullString `db:"fac_public_key"`
 	FACAdress            sql.NullString `db:"fac_address"`
 	FACPrivateKey        sql.NullString `db:"fac_private_key"`
 	FACVersion           sql.NullString `db:"fac_version"`
+	GAPublicKey          sql.NullString `db:"ga_public_key"`
+	GASignature          sql.NullString `db:"ga_signature"`
+	GAClientPublicKey    sql.NullString `db:"ga_client_public_key"`
+	GAVersion            sql.NullString `db:"ga_version"`
+	Owner                sql.NullString `db:"owner"`
 	PAPublicKey          sql.NullString `db:"pa_public_key"`
 	PAAdress             sql.NullString `db:"pa_address"`
 	SecretKey            sql.NullString `db:"secret_key"`
-	SecretKeyRequired    sql.NullBool   `db:"secret_key_required"`
-	WhitelistBlockchains pq.StringArray `db:"whitelist_blockchains"`
+	URL                  sql.NullString `db:"url"`
 	WhitelistContracts   sql.NullString `db:"whitelist_contracts"`
 	WhitelistMethods     sql.NullString `db:"whitelist_methods"`
 	WhitelistOrigins     pq.StringArray `db:"whitelist_origins"`
 	WhitelistUserAgents  pq.StringArray `db:"whitelist_user_agents"`
+	WhitelistBlockchains pq.StringArray `db:"whitelist_blockchains"`
+	MaxRelays            sql.NullInt64  `db:"max_relays"`
+	Dummy                sql.NullBool   `db:"dummy"`
+	FreeTier             sql.NullBool   `db:"free_tier"`
+	SecretKeyRequired    sql.NullBool   `db:"secret_key_required"`
+	SignedUp             sql.NullBool   `db:"signed_up"`
+	Quarter              sql.NullBool   `db:"quarter"`
+	Half                 sql.NullBool   `db:"half"`
+	ThreeQuarters        sql.NullBool   `db:"three_quarters"`
+	Full                 sql.NullBool   `db:"full"`
+	CreatedAt            sql.NullTime   `db:"created_at"`
+	UpdatedAt            sql.NullTime   `db:"updated_at"`
 }
 
 func stringToWhitelistContracts(rawContracts sql.NullString) []repository.WhitelistContract {
@@ -98,17 +107,23 @@ func stringToWhitelistMethods(rawMethods sql.NullString) []repository.WhitelistM
 func (a *dbApplication) toApplication() *repository.Application {
 	return &repository.Application{
 		ID:           a.ApplicationID,
-		ContactEmail: a.ContactEmail.String,
-		CreatedAt:    &a.CreatedAt.Time,
-		Description:  a.Description.String,
-		Name:         a.Name.String,
-		Owner:        a.Owner.String,
-		UpdatedAt:    &a.UpdatedAt.Time,
-		URL:          a.URL.String,
 		UserID:       a.UserID.String,
-		PublicPocketAccount: repository.PublicPocketAccount{
-			PublicKey: a.PAPublicKey.String,
-			Address:   a.PAAdress.String,
+		Name:         a.Name.String,
+		Status:       a.Status.String,
+		ContactEmail: a.ContactEmail.String,
+		Description:  a.Description.String,
+		Owner:        a.Owner.String,
+		URL:          a.URL.String,
+		MaxRelays:    a.MaxRelays.Int64,
+		Dummy:        a.Dummy.Bool,
+		FreeTier:     a.FreeTier.Bool,
+		CreatedAt:    &a.CreatedAt.Time,
+		UpdatedAt:    &a.UpdatedAt.Time,
+		FreeTierAAT: repository.FreeTierAAT{
+			ApplicationPublicKey: a.FAPublicKey.String,
+			ApplicationSignature: a.FASignature.String,
+			ClientPublicKey:      a.FAClientPublicKey.String,
+			Version:              a.FAVersion.String,
 		},
 		FreeTierApplicationAccount: repository.FreeTierApplicationAccount{
 			Address:    a.FACAdress.String,
@@ -116,17 +131,11 @@ func (a *dbApplication) toApplication() *repository.Application {
 			PrivateKey: a.FACPrivateKey.String,
 			Version:    a.FACVersion.String,
 		},
-		FreeTierAAT: repository.FreeTierAAT{
-			Version:              a.FAVersion.String,
-			ApplicationPublicKey: a.FAPublicKey.String,
-			ClientPublicKey:      a.FAClientPublicKey.String,
-			ApplicationSignature: a.FASignature.String,
-		},
 		GatewayAAT: repository.GatewayAAT{
-			Version:              a.GAVersion.String,
 			ApplicationPublicKey: a.GAPublicKey.String,
-			ClientPublicKey:      a.GAClientPublicKey.String,
 			ApplicationSignature: a.GASignature.String,
+			ClientPublicKey:      a.GAClientPublicKey.String,
+			Version:              a.GAVersion.String,
 		},
 		GatewaySettings: repository.GatewaySettings{
 			SecretKey:            a.SecretKey.String,
@@ -136,6 +145,17 @@ func (a *dbApplication) toApplication() *repository.Application {
 			WhitelistMethods:     stringToWhitelistMethods(a.WhitelistMethods),
 			WhitelistOrigins:     a.WhitelistOrigins,
 			WhitelistUserAgents:  a.WhitelistUserAgents,
+		},
+		NotificationSettings: repository.NotificationSettings{
+			SignedUp:      a.SignedUp.Bool,
+			Quarter:       a.Quarter.Bool,
+			Half:          a.Half.Bool,
+			ThreeQuarters: a.ThreeQuarters.Bool,
+			Full:          a.Full.Bool,
+		},
+		PublicPocketAccount: repository.PublicPocketAccount{
+			PublicKey: a.PAPublicKey.String,
+			Address:   a.PAAdress.String,
 		},
 	}
 }

--- a/postgres-driver/application.go
+++ b/postgres-driver/application.go
@@ -55,7 +55,7 @@ type dbApplication struct {
 	WhitelistOrigins     pq.StringArray `db:"whitelist_origins"`
 	WhitelistUserAgents  pq.StringArray `db:"whitelist_user_agents"`
 	WhitelistBlockchains pq.StringArray `db:"whitelist_blockchains"`
-	MaxRelays            sql.NullInt64  `db:"max_relays"`
+	MaxRelays            sql.NullInt32  `db:"max_relays"`
 	Dummy                sql.NullBool   `db:"dummy"`
 	FreeTier             sql.NullBool   `db:"free_tier"`
 	SecretKeyRequired    sql.NullBool   `db:"secret_key_required"`
@@ -114,11 +114,11 @@ func (a *dbApplication) toApplication() *repository.Application {
 		Description:  a.Description.String,
 		Owner:        a.Owner.String,
 		URL:          a.URL.String,
-		MaxRelays:    a.MaxRelays.Int64,
+		MaxRelays:    int(a.MaxRelays.Int32),
 		Dummy:        a.Dummy.Bool,
 		FreeTier:     a.FreeTier.Bool,
-		CreatedAt:    &a.CreatedAt.Time,
-		UpdatedAt:    &a.UpdatedAt.Time,
+		CreatedAt:    a.CreatedAt.Time,
+		UpdatedAt:    a.UpdatedAt.Time,
 		FreeTierAAT: repository.FreeTierAAT{
 			ApplicationPublicKey: a.FAPublicKey.String,
 			ApplicationSignature: a.FASignature.String,

--- a/postgres-driver/blockchain.go
+++ b/postgres-driver/blockchain.go
@@ -18,7 +18,7 @@ type dbBlockchain struct {
 	Blockchain        sql.NullString `db:"blockchain"`
 	Body              sql.NullString `db:"body"`
 	ChainID           sql.NullString `db:"chain_id"`
-	ChaindIDCheck     sql.NullString `db:"chain_id_check"`
+	ChainIDCheck      sql.NullString `db:"chain_id_check"`
 	Description       sql.NullString `db:"description"`
 	EnforceResult     sql.NullString `db:"enforce_result"`
 	Network           sql.NullString `db:"network"`
@@ -28,13 +28,13 @@ type dbBlockchain struct {
 	SyncCheck         sql.NullString `db:"sync_check"`
 	Ticker            sql.NullString `db:"ticker"`
 	BlockchainAliases pq.StringArray `db:"blockchain_aliases"`
-	Index             sql.NullInt64  `db:"_index"`
-	LogLimitBlocks    sql.NullInt64  `db:"log_limit_blocks"`
-	RequestTimeout    sql.NullInt64  `db:"request_timeout"`
-	SyncAllowance     sql.NullInt64  `db:"sync_allowance"`
-	NodeCount         sql.NullInt64  `db:"node_count"`
+	Index             sql.NullInt32  `db:"_index"`
+	LogLimitBlocks    sql.NullInt32  `db:"log_limit_blocks"`
+	RequestTimeout    sql.NullInt32  `db:"request_timeout"`
+	SyncAllowance     sql.NullInt32  `db:"sync_allowance"`
+	NodeCount         sql.NullInt32  `db:"node_count"`
+	Allowance         sql.NullInt32  `db:"active"`
 	Active            sql.NullBool   `db:"active"`
-	Allowance         sql.NullInt64  `db:"active"`
 }
 
 func (b *dbBlockchain) toBlockchain() *repository.Blockchain {
@@ -43,7 +43,7 @@ func (b *dbBlockchain) toBlockchain() *repository.Blockchain {
 		Altruist:          b.Altruist.String,
 		Blockchain:        b.Blockchain.String,
 		ChainID:           b.ChainID.String,
-		ChaindIDCheck:     b.ChaindIDCheck.String,
+		ChainIDCheck:      b.ChainIDCheck.String,
 		Description:       b.Description.String,
 		EnforceResult:     b.EnforceResult.String,
 		Network:           b.Network.String,
@@ -52,16 +52,16 @@ func (b *dbBlockchain) toBlockchain() *repository.Blockchain {
 		SyncCheck:         b.SyncCheck.String,
 		Ticker:            b.Ticker.String,
 		BlockchainAliases: b.BlockchainAliases,
-		Index:             b.Index.Int64,
-		LogLimitBlocks:    b.LogLimitBlocks.Int64,
-		RequestTimeout:    b.RequestTimeout.Int64,
-		SyncAllowance:     b.SyncAllowance.Int64,
+		Index:             int(b.Index.Int32),
+		LogLimitBlocks:    int(b.LogLimitBlocks.Int32),
+		RequestTimeout:    int(b.RequestTimeout.Int32),
+		SyncAllowance:     int(b.SyncAllowance.Int32),
 		Active:            b.Active.Bool,
 		SyncCheckOptions: repository.SyncCheckOptions{
 			Body:      b.Body.String,
 			ResultKey: b.ResultKey.String,
 			Path:      b.Path.String,
-			Allowance: b.Allowance.Int64,
+			Allowance: int(b.Allowance.Int32),
 		},
 	}
 }

--- a/postgres-driver/blockchain.go
+++ b/postgres-driver/blockchain.go
@@ -16,18 +16,25 @@ type dbBlockchain struct {
 	BlockchainID      string         `db:"blockchain_id"`
 	Altruist          sql.NullString `db:"altruist"`
 	Blockchain        sql.NullString `db:"blockchain"`
-	BlockchainAliases pq.StringArray `db:"blockchain_aliases"`
+	Body              sql.NullString `db:"body"`
 	ChainID           sql.NullString `db:"chain_id"`
 	ChaindIDCheck     sql.NullString `db:"chain_id_check"`
 	Description       sql.NullString `db:"description"`
-	Index             sql.NullInt64  `db:"_index"`
-	LogLimitBlocks    sql.NullInt64  `db:"log_limit_blocks"`
+	EnforceResult     sql.NullString `db:"enforce_result"`
 	Network           sql.NullString `db:"network"`
 	NetworkID         sql.NullString `db:"network_id"`
-	NodeCount         sql.NullInt64  `db:"node_count"`
 	Path              sql.NullString `db:"_path"`
-	RequestTimeout    sql.NullInt64  `db:"request_timeout"`
+	ResultKey         sql.NullString `db:"result_key"`
+	SyncCheck         sql.NullString `db:"sync_check"`
 	Ticker            sql.NullString `db:"ticker"`
+	BlockchainAliases pq.StringArray `db:"blockchain_aliases"`
+	Index             sql.NullInt64  `db:"_index"`
+	LogLimitBlocks    sql.NullInt64  `db:"log_limit_blocks"`
+	RequestTimeout    sql.NullInt64  `db:"request_timeout"`
+	SyncAllowance     sql.NullInt64  `db:"sync_allowance"`
+	NodeCount         sql.NullInt64  `db:"node_count"`
+	Active            sql.NullBool   `db:"active"`
+	Allowance         sql.NullInt64  `db:"active"`
 }
 
 func (b *dbBlockchain) toBlockchain() *repository.Blockchain {
@@ -35,17 +42,27 @@ func (b *dbBlockchain) toBlockchain() *repository.Blockchain {
 		ID:                b.BlockchainID,
 		Altruist:          b.Altruist.String,
 		Blockchain:        b.Blockchain.String,
-		BlockchainAliases: b.BlockchainAliases,
 		ChainID:           b.ChainID.String,
 		ChaindIDCheck:     b.ChaindIDCheck.String,
 		Description:       b.Description.String,
-		Index:             b.Index.Int64,
-		LogLimitBlocks:    b.LogLimitBlocks.Int64,
+		EnforceResult:     b.EnforceResult.String,
 		Network:           b.Network.String,
 		NetworkID:         b.NetworkID.String,
 		Path:              b.Path.String,
-		RequestTimeout:    b.RequestTimeout.Int64,
+		SyncCheck:         b.SyncCheck.String,
 		Ticker:            b.Ticker.String,
+		BlockchainAliases: b.BlockchainAliases,
+		Index:             b.Index.Int64,
+		LogLimitBlocks:    b.LogLimitBlocks.Int64,
+		RequestTimeout:    b.RequestTimeout.Int64,
+		SyncAllowance:     b.SyncAllowance.Int64,
+		Active:            b.Active.Bool,
+		SyncCheckOptions: repository.SyncCheckOptions{
+			Body:      b.Body.String,
+			ResultKey: b.ResultKey.String,
+			Path:      b.Path.String,
+			Allowance: b.Allowance.Int64,
+		},
 	}
 }
 

--- a/postgres-driver/load_balancer.go
+++ b/postgres-driver/load_balancer.go
@@ -20,39 +20,39 @@ const (
 
 type dbLoadBalancer struct {
 	LbID              string         `db:"lb_id"`
+	Duration          sql.NullString `db:"duration"`
 	Name              sql.NullString `db:"name"`
-	CreatedAt         sql.NullTime   `db:"created_at"`
-	UpdatedAt         sql.NullTime   `db:"updated_at"`
+	UserID            sql.NullString `db:"user_id"`
+	AppIDS            sql.NullString `db:"app_ids"`
+	Origins           pq.StringArray `db:"origins"`
+	RelaysLimit       sql.NullInt64  `db:"relays_limit"`
 	RequestTimeout    sql.NullInt64  `db:"request_timeout"`
 	Gigastake         sql.NullBool   `db:"gigastake"`
 	GigastakeRedirect sql.NullBool   `db:"gigastake_redirect"`
-	UserID            sql.NullString `db:"user_id"`
-	Duration          sql.NullString `db:"duration"`
-	RelaysLimit       sql.NullInt64  `db:"relays_limit"`
 	Stickiness        sql.NullBool   `db:"stickiness"`
-	Origins           pq.StringArray `db:"origins"`
 	UseRPCID          sql.NullBool   `db:"use_rpc_id"`
-	AppIDS            sql.NullString `db:"app_ids"`
+	CreatedAt         sql.NullTime   `db:"created_at"`
+	UpdatedAt         sql.NullTime   `db:"updated_at"`
 }
 
 func (lb *dbLoadBalancer) toLoadBalancer() *repository.LoadBalancer {
 	return &repository.LoadBalancer{
 		ID:                lb.LbID,
 		Name:              lb.Name.String,
-		CreatedAt:         lb.CreatedAt.Time,
-		UpdatedAt:         lb.UpdatedAt.Time,
+		UserID:            lb.UserID.String,
+		ApplicationIDs:    strings.Split(lb.AppIDS.String, ","),
 		RequestTimeout:    lb.RequestTimeout.Int64,
 		Gigastake:         lb.Gigastake.Bool,
 		GigastakeRedirect: lb.GigastakeRedirect.Bool,
-		UserID:            lb.UserID.String,
-		ApplicationIDs:    strings.Split(lb.AppIDS.String, ","),
 		StickyOptions: repository.StickyOptions{
 			Duration:      lb.Duration.String,
+			StickyOrigins: lb.Origins,
 			RelaysLimit:   int(lb.RelaysLimit.Int64),
 			Stickiness:    lb.Stickiness.Bool,
-			StickyOrigins: lb.Origins,
 			UseRPCID:      lb.UseRPCID.Bool,
 		},
+		CreatedAt: lb.CreatedAt.Time,
+		UpdatedAt: lb.UpdatedAt.Time,
 	}
 }
 

--- a/postgres-driver/load_balancer.go
+++ b/postgres-driver/load_balancer.go
@@ -25,8 +25,8 @@ type dbLoadBalancer struct {
 	UserID            sql.NullString `db:"user_id"`
 	AppIDS            sql.NullString `db:"app_ids"`
 	Origins           pq.StringArray `db:"origins"`
-	RelaysLimit       sql.NullInt64  `db:"relays_limit"`
-	RequestTimeout    sql.NullInt64  `db:"request_timeout"`
+	RelaysLimit       sql.NullInt32  `db:"relays_limit"`
+	RequestTimeout    sql.NullInt32  `db:"request_timeout"`
 	Gigastake         sql.NullBool   `db:"gigastake"`
 	GigastakeRedirect sql.NullBool   `db:"gigastake_redirect"`
 	Stickiness        sql.NullBool   `db:"stickiness"`
@@ -41,13 +41,13 @@ func (lb *dbLoadBalancer) toLoadBalancer() *repository.LoadBalancer {
 		Name:              lb.Name.String,
 		UserID:            lb.UserID.String,
 		ApplicationIDs:    strings.Split(lb.AppIDS.String, ","),
-		RequestTimeout:    lb.RequestTimeout.Int64,
+		RequestTimeout:    int(lb.RequestTimeout.Int32),
 		Gigastake:         lb.Gigastake.Bool,
 		GigastakeRedirect: lb.GigastakeRedirect.Bool,
 		StickyOptions: repository.StickyOptions{
 			Duration:      lb.Duration.String,
 			StickyOrigins: lb.Origins,
-			RelaysLimit:   int(lb.RelaysLimit.Int64),
+			RelaysLimit:   int(lb.RelaysLimit.Int32),
 			Stickiness:    lb.Stickiness.Bool,
 			UseRPCID:      lb.UseRPCID.Bool,
 		},

--- a/qos/chain-check.go
+++ b/qos/chain-check.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/pokt-foundation/pocket-go/provider"
 	"github.com/pokt-foundation/pocket-go/relayer"
@@ -55,7 +54,7 @@ func (c nodeChecker) NodesSupportingApp(ctx context.Context, app *repository.App
 		running++
 		go func(results chan *chainCheckResult, blockchain *repository.Blockchain) {
 			log := c.Logger.WithFields(logger.Fields{"Application": app, "Chain": chain})
-			session, err := c.SessionRetriever(ctx, app, chain.BlockchainID)
+			session, err := c.SessionRetriever(ctx, app, chain.ChainID)
 			if err != nil {
 				log.WithFields(logger.Fields{"Error": err}).Warn("Error getting session")
 				results <- nil
@@ -139,10 +138,7 @@ func (n nodeChecker) nodeSupportsChain(aat *provider.PocketAAT, blockchain *repo
 		return false, fmt.Errorf("Error relaying: %w", err)
 	}
 
-	chainID, err := strconv.ParseInt(r.RelayOutput.Response, 0, 64)
-	if err != nil {
-		return false, fmt.Errorf("Error parsing relay response: %w", err)
-	}
+	chainID := r.RelayOutput.Response
 
 	return chainID == blockchain.ChainID, nil
 }

--- a/qos/chain-check_test.go
+++ b/qos/chain-check_test.go
@@ -32,7 +32,7 @@ func TestNodeSupportsChain(t *testing.T) {
 				},
 			},
 			blockchain: repository.Blockchain{
-				ChainID: 18, // 0x12
+				ChainID: "18", // 0x12
 			},
 			expected: true,
 		},
@@ -44,7 +44,7 @@ func TestNodeSupportsChain(t *testing.T) {
 				},
 			},
 			blockchain: repository.Blockchain{
-				ChainID: 1000, // != 0x12
+				ChainID: "1000", // != 0x12
 			},
 		},
 		{
@@ -109,7 +109,7 @@ func TestNodeSupportsChain(t *testing.T) {
 }
 
 func TestNodesSupportingChain(t *testing.T) {
-	blockchain := repository.Blockchain{ChainID: 18} // 0x12
+	blockchain := repository.Blockchain{ChainID: "18"} // 0x12
 	aat := &provider.PocketAAT{
 		AppPubKey:    "applicationPublicKey",
 		ClientPubKey: "clientPublicKey",

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -108,7 +108,7 @@ type Blockchain struct {
 	Path              string           `json:"path"`
 	SyncCheck         string           `json:"syncCheck"`
 	Ticker            string           `json:"ticker"`
-	BlockchainAliases []string         `json:"blockchainAliase"`
+	BlockchainAliases []string         `json:"blockchainAliases"`
 	Index             int64            `json:"index"`
 	LogLimitBlocks    int64            `json:"logLimitBlocks"`
 	RequestTimeout    int64            `json:"requestTimeout"`

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -28,7 +28,7 @@ type Application struct {
 	Owner                      string                     `json:"owner"`
 	URL                        string                     `json:"url"`
 	Dummy                      bool                       `json:"dummy"`
-	MaxRelays                  int64                      `json:"maxRelays"`
+	MaxRelays                  int                        `json:"maxRelays"`
 	FreeTier                   bool                       `json:"freeTier"`
 	FreeTierAAT                FreeTierAAT                `json:"freeTierAAT"`
 	FreeTierApplicationAccount FreeTierApplicationAccount `json:"freeTierApplicationAccount"`
@@ -100,7 +100,7 @@ type Blockchain struct {
 	Altruist          string           `json:"altruist"`
 	Blockchain        string           `json:"blockchain"`
 	ChainID           string           `json:"chainID"`
-	ChaindIDCheck     string           `json:"chainIDCheck"`
+	ChainIDCheck      string           `json:"chainIDCheck"`
 	Description       string           `json:"description"`
 	EnforceResult     string           `json:"enforceResult"`
 	Network           string           `json:"network"`
@@ -109,10 +109,10 @@ type Blockchain struct {
 	SyncCheck         string           `json:"syncCheck"`
 	Ticker            string           `json:"ticker"`
 	BlockchainAliases []string         `json:"blockchainAliases"`
-	Index             int64            `json:"index"`
-	LogLimitBlocks    int64            `json:"logLimitBlocks"`
-	RequestTimeout    int64            `json:"requestTimeout"`
-	SyncAllowance     int64            `json:"syncAllowance"`
+	RequestTimeout    int              `json:"requestTimeout"`
+	Index             int              `json:"index"`
+	LogLimitBlocks    int              `json:"logLimitBlocks"`
+	SyncAllowance     int              `json:"syncAllowance"`
 	Active            bool             `json:"active"`
 	Redirects         []Redirects      `json:"redirects"`
 	SyncCheckOptions  SyncCheckOptions `json:"syncCheckOptions"`
@@ -129,7 +129,7 @@ type SyncCheckOptions struct {
 	Body      string `json:"body"`
 	ResultKey string `json:"resultKey"`
 	Path      string `json:"path"`
-	Allowance int64  `json:"allowance"`
+	Allowance int    `json:"allowance"`
 }
 
 // loadBalancer is an internal struct, reflects json, contains unverified fields, e.g. applicationIDs
@@ -148,7 +148,7 @@ type LoadBalancer struct {
 	Name           string   `json:"name"`
 	UserID         string   `json:"userID"`
 	ApplicationIDs []string `json:"applicationIDs,omitempty"`
-	RequestTimeout int64    `json:"requestTimeout"`
+	RequestTimeout int      `json:"requestTimeout"`
 	Gigastake      bool     `json:"gigastake"`
 	// TODO: this likely needs to be replaced with gigastake apps
 	GigastakeRedirect bool          `json:"gigastakeRedirect"`

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -142,7 +142,7 @@ type loadBalancer struct {
 	StickyOptions StickyOptions `json:"stickinessOptions"`
 }
 
-// LoadBalancer contains verified fields, e.g. applications (Referred to as Endpoint in Portal UI Backend)
+// LoadBalancer contains verified fields, e.g. applications (referred to as Endpoint on the Portal UI frontend/API)
 type LoadBalancer struct {
 	ID             string   `json:"id"`
 	Name           string   `json:"name"`

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -27,8 +27,8 @@ type Application struct {
 	Description                string                     `json:"description"`
 	Owner                      string                     `json:"owner"`
 	URL                        string                     `json:"url"`
-	MaxRelays                  int64                      `json:"maxRelays"`
 	Dummy                      bool                       `json:"dummy"`
+	MaxRelays                  int64                      `json:"maxRelays"`
 	FreeTier                   bool                       `json:"freeTier"`
 	FreeTierAAT                FreeTierAAT                `json:"freeTierAAT"`
 	FreeTierApplicationAccount FreeTierApplicationAccount `json:"freeTierApplicationAccount"`
@@ -36,8 +36,8 @@ type Application struct {
 	GatewaySettings            GatewaySettings            `json:"gatewaySettings"`
 	NotificationSettings       NotificationSettings       `json:"notificationSettings"`
 	PublicPocketAccount        PublicPocketAccount        `json:"publicPocketAccount"`
-	CreatedAt                  *time.Time                 `json:"createdAt"`
-	UpdatedAt                  *time.Time                 `json:"updatedAt"`
+	CreatedAt                  time.Time                  `json:"createdAt"`
+	UpdatedAt                  time.Time                  `json:"updatedAt"`
 }
 
 type FreeTierAAT struct {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -11,108 +11,33 @@ import (
 	logger "github.com/sirupsen/logrus"
 )
 
-type Blockchain struct {
-	ID                string   `json:"id"`
-	Altruist          string   `json:"altruist"`
-	Blockchain        string   `json:"blockchain"`
-	BlockchainAliases []string `json:"blockchainAliase"`
-	ChainID           string   `json:"chainID"`
-	ChaindIDCheck     string   `json:"chainIDCheck"`
-	Description       string   `json:"description"`
-	Index             int64    `json:"index"`
-	LogLimitBlocks    int64    `json:"logLimitBlocks"`
-	Network           string   `json:"network"`
-	NetworkID         string   `json:"networkID"`
-	Path              string   `json:"path"`
-	RequestTimeout    int64    `json:"requestTimeout"`
-	Ticker            string   `json:"ticker"`
-}
-
-type User struct {
-	ID string `json:"id"`
-}
-
-// LBs also contain this struct
-type StickyOptions struct {
-	Stickiness     bool
-	Duration       string
-	UseRPCID       bool
-	RelaysLimit    int
-	StickyOrigins  []string
-	RpcIDThreshold int
-}
-
-func (s *StickyOptions) IsEmpty() bool {
-	if !s.Stickiness {
-		return true
-	}
-	return len(s.StickyOrigins) == 0
-}
-
-// loadBalancer is an internal struct, reflects json, contains unverified fields, e.g. applicationIDs
-type loadBalancer struct {
-	ID             string   `json:"id"`
-	Name           string   `json:"name"`
-	ApplicationIDs []string `json:"applicationIDs"`
-	// User []*User
-	// TODO: load from db table/view
-	StickyOptions
-}
-
-// LoadBalancer contains verified fields, e.g. applications (Referred to as Endpoint in Portal UI Backend)
-type LoadBalancer struct {
-	ID             string    `json:"id"`
-	Name           string    `json:"name"`
-	CreatedAt      time.Time `json:"createdAt"`
-	UpdatedAt      time.Time `json:"updatedAt"`
-	RequestTimeout int64     `json:"requestTimeout"`
-	Gigastake      bool      `json:"gigastake"`
-	UserID         string    `json:"userID"`
-	ApplicationIDs []string  `json:"applicationIDs,omitempty"`
-	// TODO: use map[AppID]*Application instead (to speed-up fetchLoadBalancerApplication routine)
-	Applications []*Application
-	// User []*User
-	StickyOptions
-	// TODO: this likely needs to be replaced with gigastake apps
-	GigastakeRedirect bool
+type Repository interface {
+	GetApplication(id string) (Application, error)
+	GetBlockchain(alias string) (Blockchain, error)
+	GetLoadBalancer(id string) (LoadBalancer, error)
 }
 
 // TODO: identify fields that should be stored encrypted in-memory
 type Application struct {
-	ID                         string     `json:"id"`
-	ContactEmail               string     `json:"contactEmail"`
-	CreatedAt                  *time.Time `json:"createdAt"`
-	Description                string     `json:"description"`
-	Name                       string     `json:"name"`
-	Owner                      string     `json:"owner"`
-	UpdatedAt                  *time.Time `json:"updatedAt"`
-	URL                        string     `json:"url"`
-	UserID                     string     `json:"userID"`
-	PublicPocketAccount        `json:"publicPocketAccount"`
-	FreeTierApplicationAccount `json:"freeTierApplicationAccount"`
-	FreeTierAAT                `json:"freeTierAAT"`
-	GatewayAAT                 `json:"gatewatAAT"`
-	GatewaySettings            `json:"gatewaySettings"`
-}
-
-type PublicPocketAccount struct {
-	Address   string `json:"address"`
-	PublicKey string `json:"publicKey"`
-}
-
-type FreeTierApplicationAccount struct {
-	Address   string `json:"address" bson:"address"`
-	PublicKey string `json:"publicKey" bson:"publicKey"`
-	// TODO: likely need to store an encrypted form in memory
-	PrivateKey string `json:"privateKey" bson:"privateKey"`
-	Version    string `json:"version" bson:"version"`
-}
-
-type GatewayAAT struct {
-	Version              string `json:"version" bson:"version"`
-	ApplicationPublicKey string `json:"applicationPublicKey" bson:"applicationPublicKey"`
-	ClientPublicKey      string `json:"clientPublicKey" bson:"clientPublicKey"`
-	ApplicationSignature string `json:"applicationSignature" bson:"applicationSignature"`
+	ID                         string                     `json:"id"`
+	UserID                     string                     `json:"userID"`
+	Name                       string                     `json:"name"`
+	Status                     string                     `json:"status"`
+	ContactEmail               string                     `json:"contactEmail"`
+	Description                string                     `json:"description"`
+	Owner                      string                     `json:"owner"`
+	URL                        string                     `json:"url"`
+	MaxRelays                  int64                      `json:"maxRelays"`
+	Dummy                      bool                       `json:"dummy"`
+	FreeTier                   bool                       `json:"freeTier"`
+	FreeTierAAT                FreeTierAAT                `json:"freeTierAAT"`
+	FreeTierApplicationAccount FreeTierApplicationAccount `json:"freeTierApplicationAccount"`
+	GatewayAAT                 GatewayAAT                 `json:"gatewatAAT"`
+	GatewaySettings            GatewaySettings            `json:"gatewaySettings"`
+	NotificationSettings       NotificationSettings       `json:"notificationSettings"`
+	PublicPocketAccount        PublicPocketAccount        `json:"publicPocketAccount"`
+	CreatedAt                  *time.Time                 `json:"createdAt"`
+	UpdatedAt                  *time.Time                 `json:"updatedAt"`
 }
 
 type FreeTierAAT struct {
@@ -122,14 +47,29 @@ type FreeTierAAT struct {
 	ApplicationSignature string `json:"applicationSignature"`
 }
 
+type FreeTierApplicationAccount struct {
+	Address   string `json:"address"`
+	PublicKey string `json:"publicKey"`
+	// TODO: likely need to store an encrypted form in memory
+	PrivateKey string `json:"privateKey"`
+	Version    string `json:"version"`
+}
+
+type GatewayAAT struct {
+	ApplicationPublicKey string `json:"applicationPublicKey"`
+	ApplicationSignature string `json:"applicationSignature"`
+	ClientPublicKey      string `json:"clientPublicKey"`
+	Version              string `json:"version"`
+}
+
 type GatewaySettings struct {
-	SecretKey            string              `json:"secretKey" bson:"secretKey"`
-	SecretKeyRequired    bool                `json:"secreyKeyRequired" bson:"secreyKeyRequired"`
-	WhitelistOrigins     []string            `json:"whitelistOrigins,omitempty" bson:"whitelistOrigins,omitempty"`
-	WhitelistUserAgents  []string            `json:"whitelistUserAgents,omitempty" bson:"whitelistUserAgents,omitempty"`
-	WhitelistContracts   []WhitelistContract `json:"whitelistContracts,omitempty" bson:"whitelistContracts,omitempty"`
-	WhitelistMethods     []WhitelistMethod   `json:"whitelistMethods,omitempty" bson:"whitelistMethods,omitempty"`
-	WhitelistBlockchains []string            `json:"whitelistBlockchains,omitempty" bson:"whitelistBlockchains,omitempty"`
+	SecretKey            string              `json:"secretKey"`
+	SecretKeyRequired    bool                `json:"secreyKeyRequired"`
+	WhitelistOrigins     []string            `json:"whitelistOrigins,omitempty"`
+	WhitelistUserAgents  []string            `json:"whitelistUserAgents,omitempty"`
+	WhitelistContracts   []WhitelistContract `json:"whitelistContracts,omitempty"`
+	WhitelistMethods     []WhitelistMethod   `json:"whitelistMethods,omitempty"`
+	WhitelistBlockchains []string            `json:"whitelistBlockchains,omitempty"`
 }
 
 type WhitelistContract struct {
@@ -142,10 +82,108 @@ type WhitelistMethod struct {
 	Methods      []string `json:"methods"`
 }
 
-type Repository interface {
-	GetApplication(id string) (Application, error)
-	GetBlockchain(alias string) (Blockchain, error)
-	GetLoadBalancer(id string) (LoadBalancer, error)
+type NotificationSettings struct {
+	SignedUp      bool `json:"signedUp"`
+	Quarter       bool `json:"quarter"`
+	Half          bool `json:"half"`
+	ThreeQuarters bool `json:"threeQuarters"`
+	Full          bool `json:"full"`
+}
+
+type PublicPocketAccount struct {
+	Address   string `json:"address"`
+	PublicKey string `json:"publicKey"`
+}
+
+type Blockchain struct {
+	ID                string           `json:"id"`
+	Altruist          string           `json:"altruist"`
+	Blockchain        string           `json:"blockchain"`
+	ChainID           string           `json:"chainID"`
+	ChaindIDCheck     string           `json:"chainIDCheck"`
+	Description       string           `json:"description"`
+	EnforceResult     string           `json:"enforceResult"`
+	Network           string           `json:"network"`
+	NetworkID         string           `json:"networkID"`
+	Path              string           `json:"path"`
+	SyncCheck         string           `json:"syncCheck"`
+	Ticker            string           `json:"ticker"`
+	BlockchainAliases []string         `json:"blockchainAliase"`
+	Index             int64            `json:"index"`
+	LogLimitBlocks    int64            `json:"logLimitBlocks"`
+	RequestTimeout    int64            `json:"requestTimeout"`
+	SyncAllowance     int64            `json:"syncAllowance"`
+	Active            bool             `json:"active"`
+	Redirects         []Redirects      `json:"redirects"`
+	SyncCheckOptions  SyncCheckOptions `json:"syncCheckOptions"`
+}
+
+// TODO - Figure out how to handle Redirects field in Postgres
+type Redirects struct {
+	Alias          string `json:"alias"`
+	Domain         string `json:"domain"`
+	LoadBalancerID string `json:"loadBalancerID"`
+}
+
+type SyncCheckOptions struct {
+	Body      string `json:"body"`
+	ResultKey string `json:"resultKey"`
+	Path      string `json:"path"`
+	Allowance int64  `json:"allowance"`
+}
+
+// loadBalancer is an internal struct, reflects json, contains unverified fields, e.g. applicationIDs
+type loadBalancer struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	ApplicationIDs []string `json:"applicationIDs"`
+	// User []*User
+	// TODO: load from db table/view
+	StickyOptions StickyOptions `json:"stickinessOptions"`
+}
+
+// LoadBalancer contains verified fields, e.g. applications (Referred to as Endpoint in Portal UI Backend)
+type LoadBalancer struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	UserID         string   `json:"userID"`
+	ApplicationIDs []string `json:"applicationIDs,omitempty"`
+	RequestTimeout int64    `json:"requestTimeout"`
+	Gigastake      bool     `json:"gigastake"`
+	// TODO: this likely needs to be replaced with gigastake apps
+	GigastakeRedirect bool          `json:"gigastakeRedirect"`
+	StickyOptions     StickyOptions `json:"stickinessOptions"`
+	// TODO: use map[AppID]*Application instead (to speed-up fetchLoadBalancerApplication routine)
+	Applications []*Application
+	// User []*User
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type StickyOptions struct {
+	Duration       string   `json:"duration"`
+	StickyOrigins  []string `json:"stickyOrigins"`
+	RelaysLimit    int      `json:"relaysLimit"`
+	RpcIDThreshold int
+	Stickiness     bool `json:"stickiness"`
+	StickinessTemp bool `json:"stickinessTemp"`
+	UseRPCID       bool `json:"useRPCID"`
+}
+
+func (s *StickyOptions) IsEmpty() bool {
+	if !s.Stickiness {
+		return true
+	}
+	return len(s.StickyOrigins) == 0
+}
+
+type User struct {
+	ID string `json:"id"`
+}
+
+type AppStickiness struct {
+	ApplicationID string
+	NodeAddress   string
 }
 
 func NewRepository(jsonFilesPath string, log *logger.Logger) (Repository, error) {
@@ -215,11 +253,6 @@ func (c *cachingRepository) GetLoadBalancer(id string) (LoadBalancer, error) {
 	}
 
 	return LoadBalancer{}, fmt.Errorf("No loadbalancers found matching %s", id)
-}
-
-type AppStickiness struct {
-	ApplicationID string
-	NodeAddress   string
 }
 
 func blockchainForAlias(alias string, blockchains []Blockchain) (Blockchain, error) {


### PR DESCRIPTION
Added all of the fields in the PUB structs to the repository and postgresdriver packages for Applications, Blockchains and LoadBalancers.

I also reordered the fields so that they appear in as close to the same order as possible between the repository structs, Postgres `<model>db` structs and `to<model>` funcs.

Needs review from some devs with more experience with the Portal data.